### PR TITLE
Fixed default Web UI Couch DB URI

### DIFF
--- a/config/default.xml
+++ b/config/default.xml
@@ -30,7 +30,7 @@
     <repo_url type="svn"></repo_url>
     <repo_user>u</repo_user>
     <repo_password></repo_password>
-    <couch_uri/>
+    <couch_uri>http://127.0.0.1:5984/</couch_uri>
     <couch_is_replicated/>
     <couch_replics/>
 


### PR DESCRIPTION
It is giving problems for non-ui users and no description is provided to configure this tag, nor runtime error details.
This should temporarely fix the problem.