### PR TITLE
Adding Mint 17 *

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,13 @@ elif [[ "$os" =~ "Ubuntu 14.04".*|"Ubuntu 14.10".*|"Ubuntu Vivid Vervet (develop
     # Bug: https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
     wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
     python get-pip.py
+elif [[ "$os" =~ "Mint 17".* ]]; then
+    version="ubuntu13-10-$arch"
+    down=1
+    # Install pip from github.
+    # Bug: https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
+    wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py
+    python get-pip.py
 elif [[ "$os" =~ "Debian 7".*|"Debian 8".*|"stretch/sid".* ]]; then
     version="ubuntu13-10-$arch"
     down=1


### PR DESCRIPTION
I added some code to be able to install Faraday in Mint 17, Mint is based on Ubuntu so I use the same packages from ubuntu 13.

Tested Mint 17 & working!