### PR TITLE
Add severity for no port vulnerability

### DIFF
--- a/plugins/repo/openvas/plugin.py
+++ b/plugins/repo/openvas/plugin.py
@@ -251,7 +251,7 @@ class OpenvasPlugin(core.PluginBase):
                     
                 if item.port == "None":
                     v_id = self.createAndAddVulnToHost(h_id,item.name.encode("utf-8"),desc=item.description.encode("utf-8"),
-                                                       ref=ref)
+                                                       severity=item.severity.encode("utf-8"),ref=ref)
                 else:
                     
                     if item.service:


### PR DESCRIPTION
Review my fix for adding severity to general/tcp (no port) for instance in order to get un-patched package displayed with correct severity