### PR TITLE
Plugins API fix: rename hostname_resolution to hostnames

### DIFF
--- a/model/controller.py
+++ b/model/controller.py
@@ -815,7 +815,7 @@ class ModelController(threading.Thread):
             ipv6_address=ipv6_address, ipv6_prefix=ipv6_prefix,
             ipv6_gateway=ipv6_gateway, ipv6_dns=ipv6_dns,
             network_segment=network_segment,
-            hostname_resolution=hostname_resolution, parent_id=parent_id)
+            hostnames=hostname_resolution, parent_id=parent_id)
 
     def newService(self, name, protocol="tcp?", ports=[], status="running",
                    version="unknown", description="", parent_id=None):

--- a/plugins/plugin.py
+++ b/plugins/plugin.py
@@ -167,7 +167,7 @@ class PluginBase(object):
             ipv6_address=ipv6_address, ipv6_prefix=ipv6_prefix,
             ipv6_gateway=ipv6_gateway, ipv6_dns=ipv6_dns,
             network_segment=network_segment,
-            hostname_resolution=hostname_resolution, parent_id=host_id)
+            hostnames=hostname_resolution, parent_id=host_id)
 
         int_obj._metadata.creator = self.id
         self.__addPendingAction(modelactions.ADDINTERFACE, host_id, int_obj)


### PR DESCRIPTION
I hope the title is not misleading, I do not want to change _public_ Plugins API, I want to fix _private_ parameter name inside API