### PR TITLE
Create gentoo_requirements_extras.txt

### DIFF
--- a/gentoo_requirements_extras.txt
+++ b/gentoo_requirements_extras.txt
@@ -1,0 +1,5 @@
+dev-python/beautifulsoup
+dev-python/gevent-psycopg2
+# net-analyzer/w3af @pentoo
+#dev-python/w3af-api-client  I will have to package. 
+# https://github.com/andresriancho/w3af-api-client


### PR DESCRIPTION
package names for gentoo , 

however a generic Makefile.client
and makefile.server , might be nice to have. 

pip in Gentoo can be done,  however its like juggling lit fuses + Dynamite sticks   
 