### PR TITLE
Handles another-faraday.py-already-running exception; updated dig plugin to include more records

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,13 @@
 The PRIMARY AUTHORS are:
 
-    * Daniel Foguelman 
-    * Esteban Guillardoy 
+    * Daniel Foguelman
+    * Esteban Guillardoy
     * Ezequiel Tavella
-    * Facundo de Guzmán 
-    * Federico Kirschbaum 
+    * Facundo de Guzmán
+    * Federico Kirschbaum
     * Francisco Amato
     * Franco Linares
-    * German Riera 
+    * German Riera
     * Joaquín López Pereyra
     * Leonardo Lazzaro
     * Martín Rocha
@@ -37,3 +37,4 @@ Project contributors
     * tsxltjecwb
     * Ulisses Albuquerque
     * xtr4nge
+    * Mike Zhong (go bears)

--- a/model/api.py
+++ b/model/api.py
@@ -121,6 +121,10 @@ def _setUpAPIServer(hostname=None, port=None):
                         raise Exception("No ports available!")
                     CONF.setApiConInfo(hostname, port)
                     CONF.saveConfig()
+                elif exception.errno == 48:
+                    # Address already open
+                    # Another instance of faraday.py already running
+                    raise Exception("Another instance of faraday.py already running!")
                 else:
                     raise exception
             except Exception as e:

--- a/model/application.py
+++ b/model/application.py
@@ -149,11 +149,11 @@ class MainApplication(object):
 
             exit_code = self.app.run(self.args)
 
-        except Exception:
-            print "There was an error while starting Faraday"
-            print "-" * 50
-            traceback.print_exc()
-            print "-" * 50
+        except Exception as exception:
+            print "There was an error while starting Faraday:"
+            print "*" * 3,
+            print exception, # instead of traceback.print_exc()
+            print "*" * 3
             exit_code = -1
 
         finally:
@@ -169,7 +169,9 @@ class MainApplication(object):
         model.api.stopAPIServer()
         restapi.stopServer()
         self._model_controller.stop()
-        self._model_controller.join()
+        if self._model_controller.isAlive():
+            # runs only if thread has started, i.e. self._model_controller.start() is run first
+            self._model_controller.join()
         self.timer.stop()
         model.api.devlog("Waiting for controller threads to end...")
         return exit_code

--- a/model/commands_history.py
+++ b/model/commands_history.py
@@ -12,6 +12,8 @@ import socket
 import subprocess
 import getpass
 
+from sys import platform as _platform
+
 
 def get_private_ip():
     """
@@ -20,7 +22,6 @@ def get_private_ip():
     TODO: The problem is what happens when the machine
     has more than one private ip
     """
-    # What's the best way to do this?
     ip = socket.gethostbyname(socket.gethostname())
     if ip:
         if not ip.startswith('127'):
@@ -29,7 +30,11 @@ def get_private_ip():
     if ip:
         if not ip.startswith('127'):
             return ip
-    ip = subprocess.check_output(["ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/'"], shell=True)
+    if _platform == "linux" or _platform == "linux2": # linux
+        ip = subprocess.check_output(["ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/'"], shell=True)
+    elif _platform == "darwin": # MAC OS X
+        ip = subprocess.check_output(["ipconfig getifaddr en0 for"], shell=True)
+        ip = ip.rstrip() # removes '\n'
     return ip
 
 

--- a/model/commands_history.py
+++ b/model/commands_history.py
@@ -33,7 +33,7 @@ def get_private_ip():
     if _platform == "linux" or _platform == "linux2": # linux
         ip = subprocess.check_output(["ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1 -d'/'"], shell=True)
     elif _platform == "darwin": # MAC OS X
-        ip = subprocess.check_output(["ipconfig getifaddr en0 for"], shell=True)
+        ip = subprocess.check_output(["ifconfig | grep 'inet ' | grep -Fv 127.0.0.1 | awk '{print $2}' "], shell=True)
         ip = ip.rstrip() # removes '\n'
     return ip
 

--- a/persistence/server/server.py
+++ b/persistence/server/server.py
@@ -730,7 +730,7 @@ def get_services_number(workspace_name, **params):
     Returns:
         The amount of services in the workspace as an integer.
     """
-    return int(get_workspace_summary(workspace_name)['interfaces'])
+    return int(get_workspace_summary(workspace_name)['services'])
 
 def get_interfaces_number(workspace_name, **params):
     """

--- a/plugins/repo/dig/plugin.py
+++ b/plugins/repo/dig/plugin.py
@@ -156,8 +156,9 @@ class DigPlugin(core.PluginBase):
                             name="TXT Information",
                             text=text.encode('ascii', 'ignore'))
 
-        except:
+        except Exception as ex:
             print("some part of the dig plug-in caused an error! Please check repo/dig/plugin.py")
+            logger.error("Error from dig plugin: %s" % (ex))
             return False
 
 

--- a/plugins/repo/dig/plugin.py
+++ b/plugins/repo/dig/plugin.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """
+Updated by Mike Zhong, 25 Oct 2017.
+
 Faraday Penetration Test IDE
 Copyright (C) 2013  Infobyte LLC (http://www.infobytesec.com/)
 See the file 'doc/LICENSE' for the license information
 """
 import re
+import socket
 
 from plugins import core
 
@@ -41,33 +44,128 @@ class DigPlugin(core.PluginBase):
         # Parse results
         results = []
         answer_section_columns = [u"domain",
-                                  u"ttl", u"class", u"type", u"address"]
+                                  u"ttl", u"class", u"type", u"data"]
         for line in parsed_output:
-            results.append(dict(zip(answer_section_columns, line.split())))
+            line_split = line.split() # the first 4 elements are domain, ttl, class, type; everything else data
+            results.append(dict(zip(answer_section_columns, line_split[:4] + [line_split[4:]] )))
 
         # Create hosts is results information is relevant
-        for result in results:
-            relevant_types = [u"A", u"AAAA"]
-            if result.get(u"type") in relevant_types:
-                ip_address = result.get(u"address")
-                domain = result.get(u"domain")
+        try:
+            for result in results:
+                relevant_types = [u"A", u"AAAA", u"MX", u"NS", u"SOA", u"TXT"]
+                # TODO implement more types from https://en.wikipedia.org/wiki/List_of_DNS_record_types
 
-                # Create host
-                host = self.createAndAddHost(ip_address)
+                if result.get(u"type") in relevant_types:
 
-                # Create interface
-                if len(ip_address.split(".")) == 4:
-                    iface = self.createAndAddInterface(
-                        host,
-                        ip_address,
-                        ipv4_address=ip_address,
-                        hostname_resolution=[domain])
-                else:
-                    iface = self.createAndAddInterface(
-                        host,
-                        ip_address,
-                        ipv6_address=ip_address,
-                        hostname_resolution=[domain])
+                    # get domain
+                    domain = result.get(u"domain")
+
+
+                    # get IP address (special if type "A")
+                    if result.get(u"type") == u"A": # A = IPv4 address from dig
+                        ip_address = result.get(u"data")[0]
+                    else:                           # if not, from socket
+                        ip_address = socket.gethostbyname(domain)
+
+                    # Create host
+                    host_id = self.createAndAddHost(ip_address)
+
+                    # create interface (special if type "AAAA")
+                    if result.get(u"type") == u"AAAA": # AAAA = IPv6 address
+                        # TODO is there a function to dynamically update the paramter ipv6_address of an already-created interface?
+                        ipv6_address = result.get(u"data")[0]
+                        interface_id = self.createAndAddInterface(
+                            host_id,
+                            ip_address,
+                            ipv4_address=ip_address,
+                            ipv6_address=ipv6_address,
+                            hostname_resolution=[domain])
+                    else:
+                        interface_id = self.createAndAddInterface(
+                            host_id,
+                            ip_address,
+                            ipv4_address=ip_address,
+                            hostname_resolution=[domain])
+
+
+                    # all other TYPES that aren't 'A' and 'AAAA' are dealt here:
+                    if result.get(u"type") == u"MX": # Mail exchange record
+                        mx_priority = result.get(u"data")[0]
+                        mx_record = result.get(u"data")[1]
+
+                        service_id = self.createAndAddServiceToInterface(
+                            host_id=host_id,
+                            interface_id=interface_id,
+                            name=mx_record,
+                            protocol="SMTP",
+                            ports=[25],
+                            description="E-mail Server")
+
+                        text = "Priority: " + mx_priority
+                        self.
+
+
+
+
+
+                        (
+                            host_id=host_id,
+                            service_id=service_id,
+                            name="priority",
+                            text=text.encode('ascii', 'ignore'))
+
+                    elif result.get(u"type") == u"NS": # Name server record
+                        ns_record = result.get(u"data")[0]
+                        self.createAndAddServiceToInterface(
+                            host_id=host_id,
+                            interface_id=interface_id,
+                            name=ns_record,
+                            protocol="DNS",
+                            ports=[53],
+                            description="DNS Server")
+
+                    elif result.get(u"type") == u"SOA": # Start of Authority Record
+                        ns_record = result.get(u"data")[0] # primary namer server
+                        responsible_party = result.get(u"data")[1] # responsible party of domain
+                        timestamp = result.get(u"data")[2]
+                        refresh_zone_time = result.get(u"data")[3]
+                        retry_refresh_time = result.get(u"data")[4]
+                        upper_limit_time = result.get(u"data")[5]
+                        negative_result_ttl = result.get(u"data")[6]
+
+                        service_id = self.createAndAddServiceToInterface(
+                            host_id=host_id,
+                            interface_id=interface_id,
+                            name=ns_record,
+                            protocol="DNS",
+                            ports=[53],
+                            description="Authority Record")
+
+                        text = (
+                            "Responsible Party: " + responsible_party +
+                            "\nTimestep: " + timestamp +
+                            "\nTime before zone refresh (sec): " + refresh_zone_time +
+                            "\nTime before retry refresh (sec): " + retry_refresh_time +
+                            "\nUpper Limit before Zone is no longer authoritive (sec): " + upper_limit_time +
+                            "\nNegative Result TTL: " + negative_result_ttl)
+
+                        self.createAndAddNoteToService(
+                            host_id=host_id,
+                            service_id=service_id,
+                            name="priority",
+                            text=text.encode('ascii', 'ignore'))
+
+                    elif result.get(u"type") == u"TXT": # TXT record
+                        text = " ".join(result.get(u"data")[:])
+                        self.createAndAddNoteToHost(
+                            host_id=host_id,
+                            name="TXT Information",
+                            text=text.encode('ascii', 'ignore'))
+
+        except:
+            print("some part of the dig plug-in caused an error! Please check repo/dig/plugin.py")
+            return False
+
 
         return True
 

--- a/plugins/repo/dig/plugin.py
+++ b/plugins/repo/dig/plugin.py
@@ -102,13 +102,7 @@ class DigPlugin(core.PluginBase):
                             description="E-mail Server")
 
                         text = "Priority: " + mx_priority
-                        self.
-
-
-
-
-
-                        (
+                        self.createAndAddNoteToService(
                             host_id=host_id,
                             service_id=service_id,
                             name="priority",


### PR DESCRIPTION
I replaced the wall-of-error-text, that was thrown when the user runs faraday.py when an instance of faraday.py is already running, with a concise message. Wrote code that prevented a cannot-join-thread-before-started error that follows the exception. 

Implemented DNS type records MX, NS, SOA, and TXT for the dig plugin. Let me know if I did this correctly! 