### PR TITLE
Fix dirb plugin

### DIFF
--- a/plugins/repo/dirb/plugin.py
+++ b/plugins/repo/dirb/plugin.py
@@ -29,7 +29,7 @@ class dirbPlugin(core.PluginBase):
         self.plugin_version = "0.0.1"
         self.version = "2.22"
         self.regexpUrl = r'((http[s]?)\:\/\/([\w\.]+)[.\S]+)'
-        self._command_regex = re.compile(r'^(sudo dirb|dirb|\.\/dirb|sudo \.\/dirb).*?')
+        self._command_regex = re.compile(r'^(?:sudo dirb|dirb|\.\/dirb|sudo \.\/dirb)\s+(?:(http[s]?)\:\/\/([\w\.]+)[.\S]+)')
         self.text = []
         
 
@@ -109,11 +109,24 @@ class dirbPlugin(core.PluginBase):
         return True
 
 
+
     def processCommandString(self, username, current_path, command_string):
+        """
+        Adds the -oX parameter to get xml output to the command string that the
+        user has set.
+        """
 
-        arg = "%s -w" % command_string
-        return arg
+        no_stop_on_warn_msg_re = r"\s+-w"
+        arg_search = re.search(no_stop_on_warn_msg_re,command_string)
+        extra_arg = ""
+        if arg_search is None:
+            extra_arg +=" -w"
 
+        silent_mode_re = r"\s+-S"
+        arg_search = re.search(silent_mode_re,command_string)
+        if arg_search is None:
+            extra_arg +=" -S"
+        return "%s%s" % (command_string, extra_arg)
 
 def createPlugin():
     return dirbPlugin()


### PR DESCRIPTION
This is tiny fix for the `dirb` plugin.

First, it adds the `-S : Silent Mode` to the output, without it `faraday` got stuck when processing the command output.

To show `dirb` options you have to run the command without any option. Faraday ALWAYS added the `-w` suffix causing an error

```
$ ./dirb -w 2>&1 | tee -a tmp.J1OKOP506BsIu3su7sTgn0G3tcB3z

-----------------
DIRB v2.22    
By The Dark Raver
-----------------


(!) FATAL: Invalid URL format: -w/
    (Use: "http://host/" or "https://host/" for SSL)
```
Now the command match is done only when `dirb` also contains an url argument.