### PR TITLE
Fix for SQLmap plugin error TypeError: cannot concatenate 'str' and 'int' objects

### DIFF
--- a/plugins/repo/sqlmap/plugin.py
+++ b/plugins/repo/sqlmap/plugin.py
@@ -624,7 +624,7 @@ class SqlmapPlugin(PluginTerminalOutput):
                 self.path = urlComponents.path
                 self.params = urlComponents.query
 
-            self.url = self.protocol + "://" + self.hostname + ":" + self.port + self.path
+            self.url = self.protocol + "://" + self.hostname + ":" + int(self.port) + self.path
             self.fullpath = self.url + "?" + self.params
 
             self._output_path = "%s%s" % (


### PR DESCRIPTION
Fix self.port type error