### PR TITLE
explicitly cast execv arguments to strings

### DIFF
--- a/faraday-server.py
+++ b/faraday-server.py
@@ -178,7 +178,7 @@ def main():
             if arg not in ["start", "stop"] and arg_dict[arg]:
                 params.append('--'+arg)
                 if arg_dict[arg] != True:
-                    params.append(arg_dict[arg])
+                    params.append(str(arg_dict[arg]))
         logger.info('Faraday Server is running as a daemon')
         subprocess.Popen(params, stdout=devnull, stderr=devnull)
     else:


### PR DESCRIPTION
Fixes #274 by explicitly casting all `params` passed to `subprocess.Popen` as strings. The issue is with the port being an integer.