### PR TITLE
Fix HTTP 500 error

### DIFF
--- a/requirements_server.txt
+++ b/requirements_server.txt
@@ -9,7 +9,7 @@ Flask-Security>=3.0.0
 flask-session>=0.3.1
 flask>=1.0
 IPy>=0.83
-marshmallow>=2.15.3
+marshmallow==2.15.3
 Pillow>=4.2.1
 psycopg2>=2.7.1
 pyasn1-modules>=0.0.11


### PR DESCRIPTION
Currently, Faraday supports marshmallow 2.15.3 only (confirmed in #339 ). So current format allows any version > 2.15.3, which causes HTTP 500 error on some system. This edit requires system install mashmallow 2.15.3 and the problem should be fixed during installation process