### PR TITLE
/etc/lsb-release --> /etc/os-release

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -59,8 +59,12 @@ If you are having issues with plugins, please attach relevant files if possible.
 
 Provide information on your operating system. Example:
 
-$ cat /etc/lsb-release
-DISTRIB_ID=Ubuntu
-DISTRIB_RELEASE=16.10
-DISTRIB_CODENAME=yakkety
-DISTRIB_DESCRIPTION="Ubuntu 16.10"
+```
+$ cat /etc/os-release
+NAME="Ubuntu"
+VERSION="12.04.2 LTS, Precise Pangolin"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu precise (12.04.2 LTS)"
+VERSION_ID="12.04"
+```


### PR DESCRIPTION
Use the more standard and universal `/etc/os-release`. Read http://0pointer.de/blog/projects/os-release.html

> [1] Yes, multitude, there's at least: /etc/redhat-release, /etc/SuSE-release, /etc/debian_version, /etc/arch-release, /etc/gentoo-release, /etc/slackware-version, /etc/frugalware-release, /etc/altlinux-release, /etc/mandriva-release, /etc/meego-release, /etc/angstrom-version, /etc/mageia-release. And some distributions even have multiple, for example Fedora has already four different files.

PS : Also replace `/etc/system-release` and `/etc/lsb-release`