### PR TITLE
Upgrade to webargs 6

### DIFF
--- a/faraday/server/api/base.py
+++ b/faraday/server/api/base.py
@@ -21,7 +21,7 @@ from marshmallow import Schema, EXCLUDE, fields
 from marshmallow.validate import Length
 from marshmallow_sqlalchemy import ModelConverter
 from marshmallow_sqlalchemy.schema import ModelSchemaMeta, ModelSchemaOpts
-from webargs.flaskparser import FlaskParser, parser as parser_imported
+from webargs.flaskparser import FlaskParser
 from webargs.core import ValidationError
 from faraday.server.models import Workspace, db, Command, CommandObject
 from faraday.server.schemas import NullToBlankString
@@ -293,7 +293,7 @@ class GenericView(FlaskView):
         data. It a ``Marshmallow.Schema`` instance to perform the
         deserialization
         """
-        return FlaskParser().parse(schema, request, locations=('json',),
+        return FlaskParser().parse(schema, request, location="json",
                                    *args, **kwargs)
 
     @classmethod
@@ -1307,9 +1307,16 @@ class FilterAlchemyModelConverter(ModelConverter):
         kwargs['required'] = False
 
 
+class AutoSchemaFlaskParser(FlaskParser):
+    # It is required to use a schema class that has unknown=EXCLUDE by default.
+    # Otherwise, requests would fail if a not defined query parameter is sent
+    # (like group_by)
+    DEFAULT_SCHEMA_CLASS = AutoSchema
+
+
 class FilterSetMeta:
     """Base Meta class of FilterSet objects"""
-    parser = parser_imported
+    parser = AutoSchemaFlaskParser(location='query')
     converter = FilterAlchemyModelConverter()
 
 

--- a/faraday/server/api/modules/agent.py
+++ b/faraday/server/api/modules/agent.py
@@ -141,7 +141,7 @@ class AgentView(UpdateWorkspacedMixin,
         """
         if flask.request.content_type != 'application/json':
             abort(400, "Only application/json is a valid content-type")
-        data = self._parse_data(AgentRunSchema(), request)
+        data = self._parse_data(AgentRunSchema(unknown=EXCLUDE), request)
         agent = self._get_object(agent_id, workspace_name)
         executor_data = data['executorData']
 

--- a/pypi2nixpkgs/packages/webargs.nix
+++ b/pypi2nixpkgs/packages/webargs.nix
@@ -1,12 +1,12 @@
 { buildPythonPackage, fetchPypi, lib, marshmallow }:
 buildPythonPackage rec {
   pname = "webargs";
-  version = "5.5.3";
+  version = "6.1.0";
 
   src = builtins.fetchurl {
     url =
-      "https://files.pythonhosted.org/packages/5a/46/72d3c7e0acbdb9c79caf7e03835cd7f77163026811855b59a1eaf6c0c2e5/webargs-5.5.3.tar.gz";
-    sha256 = "16pjzc265yx579ijz5scffyfd1vsmi87fdcgnzaj2by6w2i445l7";
+      "https://files.pythonhosted.org/packages/c0/05/787ada84c00f52636327b09368ff0212861ebf44365e799126cedca20303/webargs-6.1.0.tar.gz";
+    sha256 = "0gxvd1k5czch2l3jpvgbb53wbzl2drld25rs45jcfkrwbjrpzd7b";
   };
 
   # TODO FIXME

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,12 +22,12 @@ service_identity>=17.0.0
 SQLAlchemy>=1.2.0b2
 tqdm>=4.15.0
 twisted>=18.9.0
-webargs>=5.1.0,<6.0.0
+webargs>=6.0.0
 marshmallow-sqlalchemy
 filteralchemy-fork
 filedepot>=0.5.0
 nplusone>=0.8.1
-Flask-Restless==0.17.0
+Flask-Restless>=0.17.0
 simplejson>=3.16.0
 syslog-rfc5424-formatter>=1.1.1
 simplekv>=0.13.0

--- a/tests/test_api_comment.py
+++ b/tests/test_api_comment.py
@@ -57,7 +57,7 @@ class TestCredentialsAPIGeneric(ReadOnlyAPITests):
         raw_comment = self._create_raw_comment('workspace', service.id)
         res = test_client.post(self.url(), data=raw_comment)
         assert res.status_code == 400
-        assert 'Must be one of' in res.json['messages']['object_type'][0]
+        assert 'Must be one of' in res.json['messages']['json']['object_type'][0]
 
     def test_cannot_create_comment_of_another_workspace_object(self, test_client, session, second_workspace):
         service = ServiceFactory.create(workspace=self.workspace)

--- a/tests/test_api_credentials.py
+++ b/tests/test_api_credentials.py
@@ -167,7 +167,7 @@ class TestCredentialsAPIGeneric(ReadWriteAPITests):
         }
         res = test_client.post(self.url(), data=raw_data)
         assert res.status_code == 400
-        assert res.json['messages']['_schema'] == ['Unknown parent type: Vulnerability']
+        assert res.json['messages']['json']['_schema'] == ['Unknown parent type: Vulnerability']
 
 
     def test_update_credentials(self, test_client, session, host):

--- a/tests/test_api_services.py
+++ b/tests/test_api_services.py
@@ -266,7 +266,6 @@ class TestListServiceView(ReadOnlyAPITests):
         }
         res = test_client.post(self.url(), data=data)
         assert res.status_code == 400
-        assert res.json['messages']['_schema'] == res.json['messages']['_schema']
 
     def test_load_ports_without_list(self, test_client):
         data = {

--- a/tests/test_api_vulnerability.py
+++ b/tests/test_api_vulnerability.py
@@ -1056,8 +1056,8 @@ class TestListVulnerabilityView(ReadOnlyAPITests):  # TODO migration: use read w
         res = test_client.post('/v2/ws/{0}/vulns/'.format(ws_name), data=raw_data)
         assert res.status_code == 400
         assert vuln_count_previous == session.query(Vulnerability).count()
-        assert list(res.json['messages'].keys()) == ['easeofresolution']
-        assert 'Must be one of' in res.json['messages']['easeofresolution'][0]
+        assert list(res.json['messages']['json'].keys()) == ['easeofresolution']
+        assert 'Must be one of' in res.json['messages']['json']['easeofresolution'][0]
 
     def test_create_vuln_with_null_ease_of_resolution(self,
                                                       host_with_hostnames,
@@ -1720,7 +1720,7 @@ class TestListVulnerabilityView(ReadOnlyAPITests):  # TODO migration: use read w
 
         res = test_client.post(self.url(), data=raw_data)
         assert res.status_code == 400
-        assert res.json == {u'messages': {u'_schema': [u'Parent id not found: 358302']}}
+        assert res.json == {u'messages': {'json': {u'_schema': [u'Parent id not found: 358302']}}}
 
     def test_after_deleting_vuln_ref_and_policies_remains(self, session, test_client):
         vuln = VulnerabilityFactory.create(workspace=self.workspace)
@@ -1826,7 +1826,6 @@ class TestListVulnerabilityView(ReadOnlyAPITests):  # TODO migration: use read w
              'parent_type': 'Host',
              'parent': host.id,
              'type': 'Vulnerability',
-             'refs': ''
         }
         res = test_client.post(self.url(), data=data)
         assert res.status_code == 201
@@ -2051,7 +2050,7 @@ class TestListVulnerabilityView(ReadOnlyAPITests):  # TODO migration: use read w
             policyviolations=[],
         )
         res = test_client.post(self.url(), data=raw_data)
-        assert res.json['messages']['_schema'][0] == 'Unknown parent type'
+        assert res.json['messages']['json']['_schema'][0] == 'Unknown parent type'
 
     def test_add_empty_attachment(self, test_client, session, workspace, csrf_token):
         vuln = VulnerabilityFactory.create(workspace=workspace)

--- a/tests/test_api_workspaced_base.py
+++ b/tests/test_api_workspaced_base.py
@@ -234,7 +234,9 @@ class CountTestsMixin:
                                         workspace=self.first_object.workspace))
 
         session.commit()
-        res = test_client.get(self.url() + "count/?group_by=creator_id").get_json()
+        res = test_client.get(self.url() + "count/?group_by=creator_id")
+        assert res.status_code == 200, res.json
+        res = res.get_json()
 
         creators = []
         grouped = 0
@@ -252,7 +254,9 @@ class CountTestsMixin:
                                         workspace=self.first_object.workspace))
 
         session.commit()
-        res = test_client.get(self.url() + "count/?group_by=creator_id&order=desc").get_json()
+        res = test_client.get(self.url() + "count/?group_by=creator_id&order=desc")
+        assert res.status_code == 200, res.json
+        res = res.get_json()
 
         creators = []
         grouped = 0


### PR DESCRIPTION
- Change a few things related to marshmallow 3 exclude=RAISE
  default.
- Change a lot of tests because they were relying in the webargs error
  message, which has changed from version 5 to 6.