### PR TITLE
change line source faraday_venv/bin/activate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check out our documentation for detailed information on how to install Faraday i
 ```shell
 $ pip install virtualenv
 $ virtualenv faraday_venv
-$ source faraday_env/bin/activate
+$ source faraday_venv/bin/activate
 $ git clone git@github.com:infobyte/faraday.git
 $ cd faraday
 $ git clone https://github.com/infobyte/faraday_angular_frontend.git faraday/frontend


### PR DESCRIPTION
In the line $ virtualenv faraday_venv, the directory has v on venv.
In the line  $ source faraday_env/bin/activate not.
I propose to put v on faraday_venv to avoid mistakes in copy/paste actions.