### PR TITLE
Fix: resolve TypeError in index route on fresh install (#536)

### DIFF
--- a/faraday/server/app.py
+++ b/faraday/server/app.py
@@ -414,6 +414,7 @@ def create_app(db_connection_string=None, testing=None, register_extensions_flag
         """
         Handles 404 errors of paths.
         :param ex: Exception to return.
+        :param text: Path captured by the route rules.
         :return: The exception if the path starts with the prefixes, or the default static file.
         """
         prefixes = ('/_api', '/v3', '/socket.io')

--- a/faraday/server/app.py
+++ b/faraday/server/app.py
@@ -410,7 +410,7 @@ def create_app(db_connection_string=None, testing=None, register_extensions_flag
     @app.errorhandler(404)
     @app.route('/', defaults={'text': ''})
     @app.route('/<path:text>')
-    def index(ex):
+    def index(ex=None, text=None):
         """
         Handles 404 errors of paths.
         :param ex: Exception to return.


### PR DESCRIPTION
Fixes #536
Added text=None argument to the index function in app.py to prevent TypeError when Flask routing catches paths